### PR TITLE
fix(kit.json): <- adds `README.md` to that & drops post-unpack script…

### DIFF
--- a/kit.json
+++ b/kit.json
@@ -8,6 +8,7 @@
     "kit.json",
     "barebones",
     "contracts",
+    "README.md",
     ".gitignore",
     "migrations",
     ".eslintrc.js",
@@ -15,8 +16,5 @@
     ".eslintignore",
     ".solhint.json",
     "truffle-config.js"
-  ],
-  "hooks": {
-    "post-unpack": "npm install && cd client && npm install"
-  }
+  ]
 }


### PR DESCRIPTION
… ∵ it's already a step in the `README.md`. This also makes the `unpacking` a lot faster, since it doesn't differentiate the download phase form the `npm i` phase, which latter appears to make the former take forever.